### PR TITLE
gd: hci: Allow disabling erroneous data reporting

### DIFF
--- a/system/gd/hci/controller.cc
+++ b/system/gd/hci/controller.cc
@@ -44,6 +44,10 @@ constexpr bool kDefaultErroneousDataReportingEnabled = true;
 static const std::string kPropertyErroneousDataReportingEnabled =
     "bluetooth.hci.erroneous_data_reporting.enabled";
 
+constexpr bool kDefaultErroneousDataReportingEnabled = true;
+static const std::string kPropertyErroneousDataReportingEnabled =
+    "bluetooth.hci.erroneous_data_reporting.enabled";
+
 using os::Handler;
 
 struct Controller::impl {


### PR DESCRIPTION
Certain devices may assert support for it, yet they may not genuinely possess it, resulting in a crash of the entire Bluetooth stack.

Change-Id: I5d0d90b107ddcbfd99eaccc178146333eb3bd6f8