### PR TITLE
Revert "gd: hci: Allow disabling erroneous data reporting"

### DIFF
--- a/system/gd/hci/controller.cc
+++ b/system/gd/hci/controller.cc
@@ -44,10 +44,6 @@ constexpr bool kDefaultErroneousDataReportingEnabled = true;
 static const std::string kPropertyErroneousDataReportingEnabled =
     "bluetooth.hci.erroneous_data_reporting.enabled";
 
-constexpr bool kDefaultErroneousDataReportingEnabled = true;
-static const std::string kPropertyErroneousDataReportingEnabled =
-    "bluetooth.hci.erroneous_data_reporting.enabled";
-
 using os::Handler;
 
 struct Controller::impl {


### PR DESCRIPTION
This reverts commit b2fcca2c9cabd65b8df1471105bf57be42effadc.